### PR TITLE
refactor/#12: changed switch for map & validation on SetMethod func

### DIFF
--- a/request.go
+++ b/request.go
@@ -63,20 +63,18 @@ func (e *EntityHttpRequest) SetURL(URL string) error {
 }
 
 func (e *EntityHttpRequest) SetMethod(method string) error {
-	switch method {
-	case "GET":
-		e.Method = "GET"
-	case "POST":
-		e.Method = "POST"
-	case "DELETE":
-		e.Method = "DELETE"
-	case "PUT":
-		e.Method = "PUT"
-	default:
-		return fmt.Errorf("non-existent or unacceptable method")
+	httpRequests := map[string]bool{
+		"GET":    true,
+		"POST":   true,
+		"PUT":    true,
+		"DELETE": true,
 	}
 
-	return nil
+	if request := httpRequests[method]; request {
+		e.Method = method
+		return nil
+	}
+	return fmt.Errorf("non-existent or unacceptable method")
 }
 
 func (e *EntityHttpRequest) SetUserAgent(agent string) {


### PR DESCRIPTION
## Changes
Refactored the `switch` structure into a `map`, replacing the HTTP method validation with a map-based approach. HTTP verbs are now represented as string keys paired with boolean values in the map. 

Introduced a validation layer in the `SetMethod` method to ensure that only valid HTTP methods (GET, POST, PUT, DELETE) are assigned to the Method property of the `EntityHttpRequest` structure. 

## Reasoning
This refactoring prioritizes code readability, enhances input validation and aims for easier future maintenance efforts, while preserving the same time and space complexity (O(1) for both). 
